### PR TITLE
Remove duplicate app entry point

### DIFF
--- a/CubeTimer/ContentView.swift
+++ b/CubeTimer/ContentView.swift
@@ -44,15 +44,6 @@ struct CodableColor: Codable {
     }
 }
 
-@main
-struct CubeTimerApp: App {
-    var body: some Scene {
-        WindowGroup {
-            ContentView()
-        }
-    }
-}
-
 struct ContentView: View {
     @State private var currentTime: TimeInterval = 0
     @State private var isRunning = false


### PR DESCRIPTION
## Summary
- remove redundant `@main` declaration from `ContentView.swift` so `CubeTimerApp.swift` provides the sole entry point

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68b622e20af88331b6879ba68ae51842