### PR TITLE
Fix conflicting @main attribute in tests

### DIFF
--- a/CubeTimerTests/CubeTimerTests.swift
+++ b/CubeTimerTests/CubeTimerTests.swift
@@ -5,13 +5,12 @@
 //  Created by Admin on 2025-09-01.
 //
 
-import Testing
+import XCTest
 @testable import CubeTimer
 
-struct CubeTimerTests {
+final class CubeTimerTests: XCTestCase {
 
-    @Test func example() async throws {
-        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    func testExample() throws {
+        // Write your test here. Use XCTAssert and related functions to verify your tests produce the correct results.
     }
-
 }


### PR DESCRIPTION
## Summary
- Replace the `Testing` library usage with `XCTest` in `CubeTimerTests` to avoid declaring multiple `@main` entry points when building the app

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68b6449c01908331859c9a020d34fdcb