### PR TITLE
Conform user models to Equatable to fix onChange error

### DIFF
--- a/CubeTimer/ContentView.swift
+++ b/CubeTimer/ContentView.swift
@@ -16,7 +16,7 @@ func formatTime(_ time: TimeInterval) -> String {
     }
 }
 
-struct UserProfile: Codable, Identifiable {
+struct UserProfile: Codable, Identifiable, Equatable {
     var id = UUID()
     var name: String
     var bestTime: TimeInterval = 0
@@ -27,7 +27,7 @@ struct UserProfile: Codable, Identifiable {
     var history: [SolveRecord] = []
 }
 
-struct SolveRecord: Codable, Identifiable {
+struct SolveRecord: Codable, Identifiable, Equatable {
     var id = UUID()
     let time: TimeInterval
     let date: Date
@@ -42,7 +42,7 @@ enum Penalty: Codable, Equatable {
     case none, plus2, dnf
 }
 
-struct CodableColor: Codable {
+struct CodableColor: Codable, Equatable {
     let red: Double
     let green: Double
     let blue: Double


### PR DESCRIPTION
## Summary
- Make `UserProfile`, `SolveRecord`, and `CodableColor` conform to `Equatable`
- Allows `onChange` modifier to track changes to current profile

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68b64b0f775c8331bdbc8a62e05293a7