### PR TITLE
Fix landscape layout safe area

### DIFF
--- a/CubeTimer/ContentView.swift
+++ b/CubeTimer/ContentView.swift
@@ -270,9 +270,9 @@ struct ContentView: View {
                                 }
                         )
                 }
-                .ignoresSafeArea()
             }
         }
+        .ignoresSafeArea()
         .sensoryFeedback(.impact(weight: .medium, intensity: 0.8), trigger: isRunning)
         .confettiCannon(counter: $confettiTrigger)
         .sheet(isPresented: $showingSettings) {


### PR DESCRIPTION
## Summary
- align landscape interface with screen edges by applying `ignoresSafeArea` at the `GeometryReader` level

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_68b7566888048331a42e6ffb8673f4e2