### PR TITLE
Allow portrait access to app features

### DIFF
--- a/CubeTimer/ContentView.swift
+++ b/CubeTimer/ContentView.swift
@@ -144,24 +144,54 @@ struct ContentView: View {
     var body: some View {
         GeometryReader { geometry in
             if geometry.size.width < geometry.size.height {
-                // Portrait - Show rotation instruction
-                VStack(spacing: 30) {
+                // Portrait - Show navigation and statistics, but not the timer
+                VStack(spacing: 25) {
+                    // Settings button
+                    HStack {
+                        Spacer()
+                        Button(action: { showingSettings = true }) {
+                            Image(systemName: "gearshape.fill")
+                                .font(.title2)
+                                .foregroundColor(.secondary)
+                        }
+                    }
+
                     Spacer()
-                    
-                    Image(systemName: "rotate.right")
-                        .font(.system(size: 80))
-                        .foregroundColor(.secondary)
-                    
-                    Text("Rotate to landscape")
-                        .font(.title)
+
+                    // Statistics and links
+                    VStack(spacing: 15) {
+                        Button("Statistics - \(currentProfile.name)") {
+                            showingHistory = true
+                        }
+                        .font(.title3)
                         .fontWeight(.semibold)
-                    
-                    Text("Turn your phone sideways to use the timer")
+                        .foregroundColor(.primary)
+
+                        Button("Leaderboard") {
+                            showingLeaderboard = true
+                        }
+                        .font(.body)
+                        .foregroundColor(.secondary)
+
+                        LazyVGrid(columns: [
+                            GridItem(.flexible()),
+                            GridItem(.flexible())
+                        ], spacing: 12) {
+                            StatCard(title: "Best", value: formatTime(currentProfile.bestTime), color: .green)
+                            StatCard(title: "Last", value: formatTime(currentProfile.lastTime), color: .blue)
+                            StatCard(title: "Average", value: formatTime(averageTime), color: .purple)
+                            StatCard(title: "Solves", value: "\(currentProfile.solveCount)", color: .orange)
+                            StatCard(title: "Ao5", value: formatTimeOptional(ao5), color: .teal)
+                            StatCard(title: "Ao12", value: formatTimeOptional(ao12), color: .indigo)
+                        }
+                    }
+
+                    Spacer()
+
+                    Text("Rotate to landscape to use the timer")
                         .font(.body)
                         .foregroundColor(.secondary)
                         .multilineTextAlignment(.center)
-                    
-                    Spacer()
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .padding()


### PR DESCRIPTION
## Summary
- Show settings, statistics, and leaderboard when in portrait orientation
- Reserve timer functionality for landscape orientation only

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild test -scheme CubeTimer -project CubeTimer.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b79ed8207c83319ae9d75f70f5d1dc