### PR TITLE
Add hold-to-cancel button during solves

### DIFF
--- a/CubeTimer/ContentView.swift
+++ b/CubeTimer/ContentView.swift
@@ -210,12 +210,18 @@ struct ContentView: View {
                                 .font(.title3)
                                 .foregroundColor(.secondary)
                                 .multilineTextAlignment(.center)
-                            
+
                             Text(formatTime(isInspecting ? inspectionTime : currentTime))
                                 .font(.system(size: 56, weight: .light, design: .monospaced))
                                 .foregroundColor(getTimerColor())
                         }
-                        
+
+                        if isRunning {
+                            CancelButton(themeColor: selectedButtonColor) {
+                                cancelSolve()
+                            }
+                        }
+
                         if showingNewBest {
                             Text("🎉 NEW BEST TIME! 🎉")
                                 .font(.title2)
@@ -440,7 +446,19 @@ struct ContentView: View {
 
         saveProfiles()
     }
-    
+
+    private func cancelSolve() {
+        timer?.invalidate()
+        isRunning = false
+        currentTime = 0
+        startTime = nil
+        pendingPenalty = .none
+        isInspecting = false
+        readyToStart = false
+        leftButtonPressed = false
+        rightButtonPressed = false
+    }
+
     private func loadProfiles() {
         if let decoded = try? JSONDecoder().decode([UserProfile].self, from: userProfilesData) {
             userProfiles = decoded
@@ -474,6 +492,62 @@ struct ContentView: View {
     
     }
 
+struct CancelButton: View {
+    let themeColor: Color
+    let onCancel: () -> Void
+
+    @State private var progress: CGFloat = 0
+    @State private var timer: Timer?
+
+    var body: some View {
+        GeometryReader { proxy in
+            ZStack(alignment: .leading) {
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(Color.red)
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(themeColor)
+                    .frame(width: proxy.size.width * progress)
+            }
+            .overlay(
+                Text("Cancel")
+                    .font(.headline)
+                    .foregroundColor(.white)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            )
+            .gesture(
+                DragGesture(minimumDistance: 0)
+                    .onChanged { _ in
+                        if timer == nil {
+                            startTimer()
+                        }
+                    }
+                    .onEnded { _ in
+                        reset()
+                    }
+            )
+        }
+        .frame(height: 44)
+    }
+
+    private func startTimer() {
+        progress = 0
+        timer = Timer.scheduledTimer(withTimeInterval: 0.01, repeats: true) { t in
+            progress += 0.01 / 2.0
+            if progress >= 1 {
+                t.invalidate()
+                timer = nil
+                onCancel()
+                progress = 0
+            }
+        }
+    }
+
+    private func reset() {
+        timer?.invalidate()
+        timer = nil
+        progress = 0
+    }
+}
 
 struct StatCard: View {
     let title: String


### PR DESCRIPTION
## Summary
- Add red cancel button shown while a solve is running
- Button fills with user's theme color over 2 seconds and cancels when held
- Cancel action clears current timer without recording a solve

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b79eddd77083318df3b377300120a8