### PR TITLE
Fix inspection penalty status

### DIFF
--- a/CubeTimer/ContentView.swift
+++ b/CubeTimer/ContentView.swift
@@ -311,9 +311,8 @@ struct ContentView: View {
         if isRunning { return "Solving..." }
         if isInspecting {
             // Show penalty hints during inspection window
-            let overrun = max(0, 15 - inspectionTime)
             if pendingPenalty == .dnf { return "Inspection — DNF (≥17s)" }
-            if overrun > 0 { return "Inspection — +2 if started now" }
+            if pendingPenalty == .plus2 { return "Inspection — +2 if started now" }
             return "Inspection"
         }
         if pendingPenalty == .dnf { return "DNF — over inspection (≥17s)" }


### PR DESCRIPTION
## Summary
- fix inspection timer status text logic

## Testing
- `swiftc -parse CubeTimer/ContentView.swift`
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68b79ee08da0833193a4293fad8fc4f7