### PR TITLE
Prompt user to create profile on first launch

### DIFF
--- a/CubeTimer/ContentView.swift
+++ b/CubeTimer/ContentView.swift
@@ -97,11 +97,13 @@ struct ContentView: View {
     @State private var confettiTrigger = 0
     @State private var showingHistory = false
     @State private var showingLeaderboard = false
-    
+    @State private var showingFirstUserAlert = false
+    @State private var newUserName = ""
+
     @AppStorage("userProfiles") private var userProfilesData: Data = Data()
     @AppStorage("currentUserId") private var currentUserId: String = ""
     @State private var userProfiles: [UserProfile] = []
-    @State private var currentProfile: UserProfile = UserProfile(name: "Default")
+    @State private var currentProfile: UserProfile = UserProfile(name: "")
     
     var averageTime: TimeInterval {
         guard currentProfile.solveCount > 0 else { return 0 }
@@ -302,6 +304,9 @@ struct ContentView: View {
         .sheet(isPresented: $showingLeaderboard) {
             LeaderboardView(userProfiles: userProfiles)
         }
+        .alert("New User", isPresented: $showingFirstUserAlert, actions: firstUserAlert) {
+            Text("Enter a name for your profile")
+        }
         .onAppear {
             loadProfiles()
         }
@@ -447,16 +452,11 @@ struct ContentView: View {
         }
         
         if userProfiles.isEmpty {
-            let defaultProfile = UserProfile(name: "Default")
-            userProfiles = [defaultProfile]
-            currentProfile = defaultProfile
-            currentUserId = defaultProfile.id.uuidString
-            saveProfiles()
+            showingFirstUserAlert = true
         } else if !currentUserId.isEmpty, let profile = userProfiles.first(where: { $0.id.uuidString == currentUserId }) {
             currentProfile = profile
         } else {
             currentProfile = userProfiles.first!
-            currentUserId = currentProfile.id.uuidString
             saveProfiles()
         }
     }
@@ -471,7 +471,23 @@ struct ContentView: View {
         }
         currentUserId = currentProfile.id.uuidString
     }
-    
+
+    @ViewBuilder
+    private func firstUserAlert() -> some View {
+        TextField("Name", text: $newUserName)
+        Button("Create") {
+            if !newUserName.trimmingCharacters(in: .whitespaces).isEmpty {
+                let newProfile = UserProfile(name: newUserName)
+                userProfiles = [newProfile]
+                currentProfile = newProfile
+                saveProfiles()
+                newUserName = ""
+            } else {
+                showingFirstUserAlert = true
+            }
+        }
+    }
+
     }
 
 


### PR DESCRIPTION
## Summary
- Prompt for a user name when the app is first launched
- Remove implicit creation of a "Default" profile

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68b7a0290f9483318b4a851d5aea7629