### PR TITLE
Add Swift Package manifest

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,35 @@
+// swift-tools-version: 6.1
+import PackageDescription
+
+let package = Package(
+    name: "CubeTimer",
+    platforms: [
+        .iOS(.v16)
+    ],
+    products: [
+        .library(
+            name: "CubeTimer",
+            targets: ["CubeTimer"]
+        )
+    ],
+    targets: [
+        .target(
+            name: "CubeTimer",
+            path: "CubeTimer",
+            exclude: ["CubeTimerApp.swift"],
+            resources: [
+                .process("Assets.xcassets")
+            ]
+        ),
+        .testTarget(
+            name: "CubeTimerTests",
+            dependencies: ["CubeTimer"],
+            path: "CubeTimerTests"
+        ),
+        .testTarget(
+            name: "CubeTimerUITests",
+            dependencies: ["CubeTimer"],
+            path: "CubeTimerUITests"
+        )
+    ]
+)


### PR DESCRIPTION
## Summary
- add Swift package manifest describing CubeTimer library and test targets

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68b7a071a3f08331adb3406fb3ef0b59