### PR TITLE
Adjust settings icon padding

### DIFF
--- a/CubeTimer/ContentView.swift
+++ b/CubeTimer/ContentView.swift
@@ -157,6 +157,7 @@ struct ContentView: View {
                                 .foregroundColor(.secondary)
                         }
                     }
+                    .padding(.top, 16)
 
                     Spacer()
 
@@ -233,6 +234,7 @@ struct ContentView: View {
                                     .foregroundColor(.secondary)
                             }
                         }
+                        .padding(.top, 16)
                         
                         Spacer()
                         


### PR DESCRIPTION
## Summary
- shift settings icon downward in both portrait and landscape views

## Testing
- `xcodebuild test -project CubeTimer.xcodeproj -scheme CubeTimer -destination 'platform=iOS Simulator,name=iPhone 14'` *(fails: command not found)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68b7a1f4906483319566d5c9759ef605