### PR TITLE
Keep screen awake while timer runs

### DIFF
--- a/CubeTimer/ContentView.swift
+++ b/CubeTimer/ContentView.swift
@@ -335,6 +335,7 @@ struct ContentView: View {
             }
         }
         .ignoresSafeArea()
+        .idleTimerDisabled(isRunning)
         .sensoryFeedback(.impact(weight: .medium, intensity: 0.8), trigger: isRunning)
         .confettiCannon(counter: $confettiTrigger)
         .sheet(isPresented: $showingSettings) {

--- a/CubeTimer/IdleTimerDisabled.swift
+++ b/CubeTimer/IdleTimerDisabled.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+import UIKit
+
+private struct IdleTimerDisabledModifier: ViewModifier {
+    var disabled: Bool
+
+    func body(content: Content) -> some View {
+        content
+            .onAppear { UIApplication.shared.isIdleTimerDisabled = disabled }
+            .onChange(of: disabled) { value in
+                UIApplication.shared.isIdleTimerDisabled = value
+            }
+            .onDisappear { UIApplication.shared.isIdleTimerDisabled = false }
+    }
+}
+
+extension View {
+    /// Disables the system's idle timer while `disabled` is `true`, re-enabling it when `false`.
+    func idleTimerDisabled(_ disabled: Bool) -> some View {
+        modifier(IdleTimerDisabledModifier(disabled: disabled))
+    }
+}
+


### PR DESCRIPTION
## Summary
- Introduce a SwiftUI view modifier to toggle the system idle timer
- Apply modifier in `ContentView` to keep the screen awake only while a solve is in progress

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68b86f9510348331b4d91ed44f2f48f5